### PR TITLE
feat: Add support for response layout for the habit grid

### DIFF
--- a/web/habit-tracker/src/components/Home/index.js
+++ b/web/habit-tracker/src/components/Home/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react';
-import { Grid } from '@material-ui/core';
+import { Grid, useMediaQuery } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
 import moment from 'moment';
 import uuid from 'react-uuid';
 import { styles } from '../../styles/Home/index.styles';
@@ -11,15 +12,37 @@ import { Link } from 'react-router-dom';
 import { DataProviderContext } from '../../providers/DataProvider';
 import AddHabitDialog from '../dialogs/AddHabitDialog';
 
+const daysToDisplay = {
+  xs: 5,
+  sm: 7,
+  md: 10,
+  lg: 14,
+  xl: 14,
+};
+
+const useWidth = () => {
+  const theme = useTheme();
+  const keys = [...theme.breakpoints.keys].reverse();
+  return (
+    keys.reduce((output, key) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const matches = useMediaQuery(theme.breakpoints.up(key));
+      return !output && matches ? key : output;
+    }, null) || 'xs'
+  );
+};
+
 const Home = (props) => {
   const { classes } = props;
+
+  let width = useWidth();
+  let MAX_DAYS = daysToDisplay[width];
 
   const [endDate, setEndDate] = useState(new Date());
   const [shouldShowAddHabitDialog, setShouldShowAddHabitDialog] = useState(false);
 
   const { userData, timeSeries, updateUserData, updateTimeSeries } = useContext(DataProviderContext);
 
-  const MAX_DAYS = 14;
   const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   const habitClicked = (habitInfo) => {
@@ -70,7 +93,7 @@ const Home = (props) => {
       <Grid item xs={12}>
         <Grid container justify="center">
           <Grid item xs={2} />
-          <Grid item xs={6} md={8} className={classes.habitGrid}>
+          <Grid item xs={6} md={8} className={classes.dateGrid}>
             {buildDateLabel()}
           </Grid>
         </Grid>

--- a/web/habit-tracker/src/styles/Home/index.styles.js
+++ b/web/habit-tracker/src/styles/Home/index.styles.js
@@ -28,9 +28,14 @@ export const styles = (theme) => ({
   selectedHabitColor: {
     backgroundColor: '#8cc665',
   },
+  dateGrid: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
   dateHeader: {
     height: 48,
     width: 48,
+    margin: 4,
     textAlign: 'center',
     flexShrink: 0,
   },


### PR DESCRIPTION
- Display 5 days of data for xs
- Display 7 days of data for sm
- Display 10 days of data for md
- Display 14 days of data for lg and xl
- Update styles to make the date header transform uniformly with the check boxes